### PR TITLE
add react-native-permissions dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-native-material-menu": "^1.0.0",
     "react-native-modal": "^11.3.1",
     "react-native-os": "^1.0.1",
+    "react-native-permissions": "^2.1.5",
     "react-native-qrcode": "^0.2.7",
     "react-native-qrcode-scanner": "^1.2.1",
     "react-native-qrcode-svg": "^5.2.0",


### PR DESCRIPTION
Fixes the `react-native run-android` build error.